### PR TITLE
Fix horizontal scroll

### DIFF
--- a/actdocs/templates/footers/conferences
+++ b/actdocs/templates/footers/conferences
@@ -1,5 +1,5 @@
 [% IF 1 || global.conferences.present.merge( global.conferences.future ).size %]
-<div class="row row-more-act">
+<div class="row-more-act">
   <div class="container">
     <div class="col-sm-12">
       <h3 class="more-act-bar">


### PR DESCRIPTION
When using a structure like '.row' > '.container' > '.col-sm-12' the footer's total width is 100% (of body) plus margins. This causes a permanent mini horizontal-scroll. Removing the 'row' class prevents this and leaves the position of the elements untouched.