### PR TITLE
fix wrong indentation

### DIFF
--- a/actdocs/static/courses.html
+++ b/actdocs/static/courses.html
@@ -129,7 +129,7 @@
                 <!--<li><s>Early-bird (up to 1-June-2015): 150 Euro</s></li>-->
                 <li>Regular price: 200 Euro</li>
             </ul>
-
+    </ul>
 
 
   <p>


### PR DESCRIPTION
Should align the last course with the rest (tested in a local instance).