### PR TITLE
Added 'back to list' footer to one talk page

### DIFF
--- a/actdocs/templates/core/talk/show
+++ b/actdocs/templates/core/talk/show
@@ -186,5 +186,6 @@
 
       </div>
     </div>
+    <div class="panel-footer"><a href="[% make_uri('talks') %]">&laquo; {{List of talks}}</a></div>
   </div>
 </div>


### PR DESCRIPTION
Argh :rage4:, I hate navigating back to talk list with dropdowns or by back button, so added this.

Also I am on agreement/request (or anyone of you) can add same back-link to panel header:
```html
<div class="panel-heading"><a href="[% make_uri('talks') %]">&laquo; {{List of talks}}</a></div>
````
right after `<div class="panel panel-default">` in actdocs/templates/core/talk/show