### PR TITLE
Now also 'accepted' type of tasks in user's tasks list have fav-button.

### DIFF
--- a/actdocs/templates/user/show
+++ b/actdocs/templates/user/show
@@ -150,7 +150,7 @@
                 <span class="label label-warning">{{Pending}}</span>
               [% END %]
             </td>
-            [% IF t.confirmed %]
+            [% IF t.confirmed OR t.accepted %]
             <td width="30">
               [% PROCESS talk/fav_ajax onetalk = t %]
             </td>


### PR DESCRIPTION
Before that button was only near 'confirmed'.

Simple line.