### PR TITLE
change the scheduling room order

### DIFF
--- a/actdocs/conf/act.ini
+++ b/actdocs/conf/act.ini
@@ -29,7 +29,7 @@ level2_name_en = Intermediate
 level3_name_en = Advanced
 
 [rooms]
-rooms = r1 r2 r3 r4 r5
+rooms = r5 r4 r3 r2 r1
 r1_name_en = Hall
 r2_name_en = Salon de Grados
 r3_name_en = Aula F2


### PR DESCRIPTION
The schedule shows the Aula Magna room to the right which is a bad thing.