### PR TITLE
set room order in the schedule template

### DIFF
--- a/actdocs/templates/core/talk/schedule
+++ b/actdocs/templates/core/talk/schedule
@@ -95,7 +95,8 @@
                 <th>
                   {{Time}}
                 </th>
-                [% FOREACH r IN room.keys.sort %]
+                [%-# tweak to get the right room order in schedule w/o messing act.ini %]
+                [% FOREACH r IN room.keys.sort.reverse %]
                   [% IF width.$r.$d %]
                     <th colspan="[% width.$r.$d %]">[% r == 'sidetrack' ? loc('room_sidetrack') : global.config.rooms.$r %]</th>
                   [% END %]


### PR DESCRIPTION
Order from rooms list in act.ini is lost when it's converted into a hash.