### PR TITLE
Fix schedule style

### DIFF
--- a/wwwdocs/css/style.css
+++ b/wwwdocs/css/style.css
@@ -76,33 +76,26 @@ p.message {
 }
 .table-schedule td {
   border: 0 !important;
-  position: relative;
 }
-.table-schedule td .alert {
-  position: absolute;
-  display: block;
-  width: 100%;
-  height: 100%;
-}
-.venue .alert {
+td.venue {
   background-color: #FFCC00;
 }
-.out .alert {
+td.out {
   background-color: #EEEEEE;
 }
-.r1 .alert {
+td.r1 {
   background-color: #FFD3D3;
 }
-.r2 .alert {
+td.r2 {
   background-color: #D3FFD3;
 }
-.r3 .alert {
+td.r3 {
   background-color: #D3D3FF;
 }
-.r4 .alert {
+td.r4 {
   background-color: #FFFFD3;
 }
-.r5 .alert {
+td.r5 {
   background-color: #D3FFFF;
 }
 .mtbutton {


### PR DESCRIPTION
Cells don't work with position: absolute. I made the decision to ignore the alerts and set the colors on td's directly. We lose border-radius and spaces but right now I think it's the safest fix.