### PR TITLE
retain previous confirmed value in edittalk

### DIFF
--- a/actdocs/templates/talk/add
+++ b/actdocs/templates/talk/add
@@ -76,7 +76,7 @@
                   <span class="label label-success">{{confirmed}}</span>
                 [% ELSIF accepted %]
                   <span class="label label-info">{{Accepted}}</span> (not confirmed)
-                  <input type="checkbox" name="confirmed" /> {{confirmed}}<br />
+                  <input type="checkbox" name="confirmed"[% ' checked' IF confirmed %] /> {{confirmed}}<br />
                 [% ELSE %]
                   <span class="label label-warning">{{Pending}}</span>
                 [% END %]


### PR DESCRIPTION
Should fix the issue that unexpectedly unconfirms talks without speakers noticing.